### PR TITLE
change user.yaml from OADC to G3DH

### DIFF
--- a/unfunded/gen3.datacommons.io/values/fence.yaml
+++ b/unfunded/gen3.datacommons.io/values/fence.yaml
@@ -18,7 +18,7 @@ fence:
   usersync:
     # -- (bool) Whether to run Fence usersync or not.
     usersync: true
-    userYamlS3Path: s3://cdis-gen3-users/oadc/user.yaml
+    userYamlS3Path: s3://cdis-gen3-users/g3dh/user.yaml
 
   USER_YAML:
 


### PR DESCRIPTION
when we added the clopidogrel study to OADC (open access data commons), we changed the name to Gen3 Data Hub (since that study is not open access). We created a new user.yaml at the time. We are moving to use the g3dh user.yaml to prevent confusion in the commons-users repo
