### PR TITLE
removing properties from ETL mapping that are missing from data model…

### DIFF
--- a/chordsprod/staging.chordshealth.org/values/etl.yaml
+++ b/chordsprod/staging.chordshealth.org/values/etl.yaml
@@ -39,7 +39,7 @@ etl:
           - name: spatial_bounding_box
           - name: exposure_media
         parent_props:
-          - path: resources[resource_short_name:short_name, resource_url, resource_description:description, domain, keywords, access_type, strengths, limitations, example_applications, tools_supporting_uses].projects[project_sponsor, project_sponsor_type]
+          - path: resources[resource_short_name:short_name, resource_url, resource_description:description, domain, keywords, access_type].projects[project_sponsor, project_sponsor_type]
       - name: chordstaging_population_data_resource
         doc_type: population_data_resource
         type: aggregator
@@ -66,7 +66,7 @@ etl:
           - name: model_methods
           - name: population_studied
         parent_props:
-          - path: resources[resource_short_name:short_name, resource_url, resource_description:description, domain, keywords, access_type, strengths, limitations, example_applications, tools_supporting_uses].projects[project_sponsor, project_sponsor_type]
+          - path: resources[resource_short_name:short_name, resource_url, resource_description:description, domain, keywords, access_type].projects[project_sponsor, project_sponsor_type]
       - name: chordstaging_key_dataset_resource
         doc_type: key_data_resource
         type: aggregator
@@ -87,10 +87,9 @@ etl:
           - name: temporal_resolution
           - name: spatial_resolution
           - name: spatial_coverage
-          - name: spatial_coverage_specific_regions
           - name: geometry_type
           - name: model_methods
           - name: data_formats
           - name: data_location_text
         parent_props:
-          - path: resources[resource_short_name:short_name, resource_url, resource_description:description, domain, keywords, access_type, strengths, limitations, example_applications, tools_supporting_uses].projects[project_sponsor, project_sponsor_type]
+          - path: resources[resource_short_name:short_name, resource_url, resource_description:description, domain, keywords, access_type].projects[project_sponsor, project_sponsor_type]


### PR DESCRIPTION
CHORDS is having ETL issues; discovered several properties in the ETL mapping that don't exist in the data model version they're currently using (v1.5.3: https://s3.amazonaws.com/dictionary-artifacts/chords-health-dictionary/1.5.3/schema.json).
Removed the missing properties so we can try to re-run the ETL.
Specifically this is what was removed:

* In each parent_props section of all indexes for the resource node: strengths, limitations, example_applications, tools_supporting_uses
* For key_data_resource node: spatial_coverage_specific_regions