### PR TITLE
Adding PDB for Postgres and Elasticsearch

### DIFF
--- a/ci/default/values/values.yaml
+++ b/ci/default/values/values.yaml
@@ -45,10 +45,6 @@ postgresql:
     tag: 14.5.0-debian-11-r35
 
 elasticsearch:
-  volumeClaimTemplate:
-    resources:
-      requests:
-        storage: 1Gi
   pdb:
     create: true
     minAvailable: "1"

--- a/ci/default/values/values.yaml
+++ b/ci/default/values/values.yaml
@@ -45,7 +45,6 @@ postgresql:
     tag: 14.5.0-debian-11-r35
 
 elasticsearch:
-  maxUnavailable: ""
   volumeClaimTemplate:
     resources:
       requests:

--- a/ci/default/values/values.yaml
+++ b/ci/default/values/values.yaml
@@ -35,6 +35,10 @@ postgresql:
     persistence:
       enabled: true
       size: 1Gi
+  pdb:
+    create: true
+    minAvailable: "1"
+    maxUnavailable: "0"
   image:
     registry: quay.io
     repository: cdis/postgresql
@@ -46,3 +50,7 @@ elasticsearch:
     resources:
       requests:
         storage: 1Gi
+  pdb:
+    create: true
+    minAvailable: "1"
+    maxUnavailable: "0"


### PR DESCRIPTION
adding PDB to prevent Postgres and Elasticsearch from being disturbed during CI runs.