### PR TITLE
adding webacl to dcf prod and staging.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -294,66 +294,6 @@
         "line_number": 389
       }
     ],
-    "dcf-staging/nci-crdc-staging.datacommons.io/values/values.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "dcf-staging/nci-crdc-staging.datacommons.io/values/values.yaml",
-        "hashed_secret": "0e97c45191db62225d4662bbafc3f338b4e0bd94",
-        "is_verified": false,
-        "line_number": 94
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dcf-staging/nci-crdc-staging.datacommons.io/values/values.yaml",
-        "hashed_secret": "08478a51ae919f47112d86a9fba3e4e19fb1f94b",
-        "is_verified": false,
-        "line_number": 95
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dcf-staging/nci-crdc-staging.datacommons.io/values/values.yaml",
-        "hashed_secret": "dfe79f4d980cdfbba471cfe6d9078f928577109c",
-        "is_verified": false,
-        "line_number": 126
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dcf-staging/nci-crdc-staging.datacommons.io/values/values.yaml",
-        "hashed_secret": "7120244dce59930b75711144fda4b1f6d78e4865",
-        "is_verified": false,
-        "line_number": 518
-      }
-    ],
-    "dcfprod/nci-crdc.datacommons.io/values/values.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "dcfprod/nci-crdc.datacommons.io/values/values.yaml",
-        "hashed_secret": "6779aff449d45c2d748cdd602e7f0d8ee0e0a734",
-        "is_verified": false,
-        "line_number": 1035
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dcfprod/nci-crdc.datacommons.io/values/values.yaml",
-        "hashed_secret": "b2111a5070563f0ad4fec22d43571e18d09f119f",
-        "is_verified": false,
-        "line_number": 1036
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dcfprod/nci-crdc.datacommons.io/values/values.yaml",
-        "hashed_secret": "5363381a128ce25cb36e96a5ef165204e6d70374",
-        "is_verified": false,
-        "line_number": 1064
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "dcfprod/nci-crdc.datacommons.io/values/values.yaml",
-        "hashed_secret": "7120244dce59930b75711144fda4b1f6d78e4865",
-        "is_verified": false,
-        "line_number": 1466
-      }
-    ],
     "emalinowskiv1/emalinowskiv1.planx-pla.net/values/values.yaml": [
       {
         "type": "Secret Keyword",
@@ -532,5 +472,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-16T15:36:28Z"
+  "generated_at": "2025-09-17T14:49:25Z"
 }

--- a/dcf-staging/nci-crdc-staging.datacommons.io/values/values.yaml
+++ b/dcf-staging/nci-crdc-staging.datacommons.io/values/values.yaml
@@ -115,6 +115,11 @@ global:
     secretStoreServiceAccount:
       enabled: true
       roleArn: arn:aws:iam::584476192960:role/dcf-staging-external-secrets-sa
+    wafv2:
+      # -- (bool) Set to true if using AWS WAFv2
+      enabled: true
+      # -- (string) ARN for the WAFv2 ACL.
+      wafAclArn: "arn:aws:wafv2:us-east-1:584476192960:regional/webacl/dcf-staging-waf/541a5a0d-56c7-4de0-af1e-d5c74cb2210f"
   dev: false
   dictionaryUrl: https://s3.amazonaws.com/dictionary-artifacts/datadictionary/develop/schema.json
   dispatcherJobNum: '10'

--- a/dcfprod/nci-crdc.datacommons.io/values/values.yaml
+++ b/dcfprod/nci-crdc.datacommons.io/values/values.yaml
@@ -695,7 +695,7 @@ fence:
       kf-study-us-east-1-prd-sd-w0v965xz:
         cred: "fence_bot"
         region: "us-east-1"
-      kf-study-us-east-1-prd-sd-z0d9n23x: 
+      kf-study-us-east-1-prd-sd-z0d9n23x:
         cred: "fence_bot"
         region: "us-east-1"
       kf-study-us-east-1-prd-sd-zfgdg5ys:
@@ -1063,6 +1063,11 @@ global:
     secretStoreServiceAccount:
       enabled: true
       roleArn: arn:aws:iam::584476192960:role/dcfprod--dcfprod-helm--external-secrets-sa
+    wafv2:
+      # -- (bool) Set to true if using AWS WAFv2
+      enabled: true
+      # -- (string) ARN for the WAFv2 ACL.
+      wafAclArn: "arn:aws:wafv2:us-east-1:584476192960:regional/webacl/dcfprod-waf/fb6cb3a2-31cd-4cab-b0ff-44f09d955958"
   dev: false
   dictionaryUrl: https://s3.amazonaws.com/dictionary-artifacts/datadictionary/develop/schema.json
   dispatcherJobNum: '10'


### PR DESCRIPTION
We deployed the fresh new base ruleset for WAF and now we need to ensure each helm env is associated with its respective WAF.