### PR TITLE
updating kidsfirst to have WAF associated.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,7 +332,7 @@
         "filename": "kidsfirst-kfqa2/gen3qa.kidsfirstdrc.org/values/values.yaml",
         "hashed_secret": "cf17f42c0c730b5582614d768b907020ceedbfe2",
         "is_verified": false,
-        "line_number": 236
+        "line_number": 235
       }
     ],
     "kidsfirst-prodv1/data.kidsfirstdrc.org/values/values.yaml": [
@@ -436,5 +436,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-24T16:19:58Z"
+  "generated_at": "2025-09-25T17:03:21Z"
 }

--- a/kidsfirst-kfqa2/gen3qa.kidsfirstdrc.org/values/values.yaml
+++ b/kidsfirst-kfqa2/gen3qa.kidsfirstdrc.org/values/values.yaml
@@ -72,6 +72,11 @@ global:
     secretStoreServiceAccount:
       enabled: true
       roleArn: arn:aws:iam::222487244010:role/kfqa2-external-secrets-sa
+    wafv2:
+      # -- (bool) Set to true if using AWS WAFv2
+      enabled: true
+      # -- (string) ARN for the WAFv2 ACL.
+      wafAclArn: "arn:aws:wafv2:us-east-1:222487244010:regional/webacl/kfqa2-waf/4b538e50-e586-4bc5-9c91-2b8677a15cba"
   dev: false
   dictionaryUrl: https://s3.amazonaws.com/dictionary-artifacts/kf-dictionary/develop/schema.json
   environment: kfqa2


### PR DESCRIPTION
Was missing a waf association on the ALB for this commons.