### PR TITLE
Disable gen3-workflow by default in CI

### DIFF
--- a/ci/default/values/gen3-workflow.yaml
+++ b/ci/default/values/gen3-workflow.yaml
@@ -1,5 +1,5 @@
 gen3-workflow:
-  enabled: true
+  enabled: false
   image:
     repository: quay.io/cdis/gen3-workflow
     tag: master


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
* CI

### Description of changes
* Disable gen3-workflow by default in CI, and enable them onlky for required PRs in code-vigil
