### PR TITLE
Temporarily Revert consolidation policy to WhenEmptyOrUnderutilized in BRH

### DIFF
--- a/brhprod/cluster-values/cluster-values.yaml
+++ b/brhprod/cluster-values/cluster-values.yaml
@@ -72,7 +72,7 @@ karpenter-crds:
     amiFamily: AL2023
     limits:
       memory: 1100Gi
-    consolidationPolicy: "WhenEmpty"
+    consolidationPolicy: "WhenEmptyOrUnderutilized"
     consolidateAfter: "1m"
     expireAfter: "72h"
     volumeSize: 80Gi


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
* BRH Staging / Prod

### Description of changes
* Revert consolidation policy to WhenEmptyOrUnderutilized to trigger pod restarts due to Karpenter rescheduling.
