### PR TITLE
VPODC FF 0.15 release

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -855,15 +855,6 @@
         "line_number": 27
       }
     ],
-    "vadcprod/vpodc.data-commons.org/values/values.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "vadcprod/vpodc.data-commons.org/values/values.yaml",
-        "hashed_secret": "1f917176352c700f628c0c17f94d0d30b20c2ba9",
-        "is_verified": false,
-        "line_number": 141
-      }
-    ],
     "vhdcprod/va.data-commons.org/values/values.yaml": [
       {
         "type": "Base64 High Entropy String",
@@ -874,5 +865,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-01T18:50:20Z"
+  "generated_at": "2026-05-04T16:20:21Z"
 }

--- a/vadcprod/vpodc.data-commons.org/values/values.yaml
+++ b/vadcprod/vpodc.data-commons.org/values/values.yaml
@@ -116,7 +116,7 @@ frontend-framework:
   enabled: true
   image:
     repository: quay.io/cdis/vpodc-data-commons
-    tag: 0.14
+    tag: 0.15
 global:
   pdb: true
   aws:


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
VPODC

### Description of changes
* (VPODC-355): Add 'select source' step to the FE by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/98
* (MC2DP-734): fix favicon by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/99
* (VPODC-382): Add Email Support to top nav by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/100
* VPODC-294: Add Results app table by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/101
* chore: Sync from template repo for 2026-04-28 by @PlanXCyborg in https://github.com/uc-cdis/vpodc-data-commons/pull/102
* (VPODC-417 VPODC-428 VPODC-427 VPODC-429): nav updates small text changes by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/103
* Chore/change data modal by @urvi-occ in https://github.com/uc-cdis/vpodc-data-commons/pull/104
* move prod changes to QA by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/105
