### PR TITLE
deploying data model 1.4.2

### DIFF
--- a/midrcprod/staging.midrc.org/values/values.yaml
+++ b/midrcprod/staging.midrc.org/values/values.yaml
@@ -542,7 +542,7 @@ global:
       enabled: true
       wafAclArn: arn:aws:wafv2:us-east-1:813684607867:regional/webacl/midrcprod-waf/6dae1fe2-287d-4cec-9537-0b8fa1f7d93c
   dev: false
-  dictionaryUrl: https://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.4.2_draft/schema.json
+  dictionaryUrl: https://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.4.2/schema.json
   dispatcherJobNum: '10'
   environment: midrcstaging
   externalSecrets:


### PR DESCRIPTION
deploying data model 1.4.2: adds dicom_header_file_guid to imaging series nodes