### PR TITLE
reverting explorer update to fix errors

### DIFF
--- a/midrcprod/data.midrc.org/values/portal/gitops.json
+++ b/midrcprod/data.midrc.org/values/portal/gitops.json
@@ -1151,7 +1151,6 @@
                     "study_uid",
                     "case_ids",
                     "object_id",
-                    "dicom_header_file_guid",
                     "project_id",
                     "_radiology_report_count"
                 ],
@@ -1697,7 +1696,6 @@
                     "study_uid",
                     "case_ids",
                     "object_id",
-                    "dicom_header_file_guid",
                     "submitter_id",
                     "project_id"
                 ],


### PR DESCRIPTION
MIDRC prod explorer is having issues bc guppy index doesn't match explorerConfig. This PR reverts the explorerConfig update and should fix the errors.