### PR TITLE
Remove typo in ETL mapping index name

### DIFF
--- a/vadcprod/vpodc.data-commons.org/values/values.yaml
+++ b/vadcprod/vpodc.data-commons.org/values/values.yaml
@@ -69,7 +69,7 @@ etl:
             props:
               - name: submitter_id
               - name: project_id
-        name: file_tube_etl_mickey
+        name: file_etl_mickey
         props:
           - name: object_id
           - name: md5sum


### PR DESCRIPTION
remove "tube" from file_tube_etl_mickey

Link to Jira ticket if there is one: 

### Environments


### Description of changes

