### PR TITLE
BRH staging TES 32 mem limit

### DIFF
--- a/brhprod/brhstaging.data-commons.org/values/values.yaml
+++ b/brhprod/brhstaging.data-commons.org/values/values.yaml
@@ -134,6 +134,9 @@ funnel:
       Worker:
         restartPolicy: Never
         backoffLimit: 1
+      Resources:
+        Limits:
+          RamGb: 32768Mi
 global:
   pdb: true
   netPolicy:


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
BRH staging

### Description of changes
Increase the TES task memory limit from [4G (default)](https://github.com/calypr/helm-charts/blob/a0481c2/charts/funnel/values.yaml#L478) to 32G