### PR TITLE
CI - Remove 'researcher_role' from allowed scopes

### DIFF
--- a/ci/default/values/fence.yaml
+++ b/ci/default/values/fence.yaml
@@ -81,8 +81,6 @@ fence:
       - "google_service_account"
       - "google_link"
       - "ga4gh_passport_v1"
-      - "profile"
-      - "email"
 
     # -- (list) these are the scopes that CAN be included in a user's own access_token
     USER_ALLOWED_SCOPES:
@@ -95,8 +93,6 @@ fence:
       - "google_service_account"
       - "google_link"
       - "ga4gh_passport_v1"
-      - "profile"
-      - "email"
 
     # -- (list) these are the scopes that a browser session can create for a user (very similar to USER_ALLOWED_SCOPES, as the session will actually create access_tokens for an actively logged in user)
     SESSION_ALLOWED_SCOPES:
@@ -109,8 +105,6 @@ fence:
       - "google_service_account"
       - "google_link"
       - "ga4gh_passport_v1"
-      - "profile"
-      - "email"
 
     # //////////////////////////////////////////////////////////////////////////////////////
     # LOGIN

--- a/ci/default/values/fence.yaml
+++ b/ci/default/values/fence.yaml
@@ -83,7 +83,6 @@ fence:
       - "ga4gh_passport_v1"
       - "profile"
       - "email"
-      - "researcher_role"
 
     # -- (list) these are the scopes that CAN be included in a user's own access_token
     USER_ALLOWED_SCOPES:
@@ -98,7 +97,6 @@ fence:
       - "ga4gh_passport_v1"
       - "profile"
       - "email"
-      - "researcher_role"
 
     # -- (list) these are the scopes that a browser session can create for a user (very similar to USER_ALLOWED_SCOPES, as the session will actually create access_tokens for an actively logged in user)
     SESSION_ALLOWED_SCOPES:
@@ -113,7 +111,6 @@ fence:
       - "ga4gh_passport_v1"
       - "profile"
       - "email"
-      - "researcher_role"
 
     # //////////////////////////////////////////////////////////////////////////////////////
     # LOGIN


### PR DESCRIPTION
Removed 'researcher_role' from various allowed scopes.

Link to Jira ticket if there is one: 

### Environments
- CI

### Description of changes
- Remove 'researcher_role' from allowed scopes
