### PR TITLE
minicommons : turn off metadata service

### DIFF
--- a/pdp-external/externalgen3.prometheus.data-commons.org/values/values.yaml
+++ b/pdp-external/externalgen3.prometheus.data-commons.org/values/values.yaml
@@ -263,7 +263,7 @@ sheepdog:
 
 metadata:
   useAggMds: false
-  enabled: true
+  enabled: false
   replicaCount: 2
 
   # Lower cost


### PR DESCRIPTION
Link to Jira ticket if there is one: [MC2DP-807](https://ctds-planx.atlassian.net/browse/MC2DP-807)

### Environments
externalgen3.prometheus.data-commons.org

### Description of changes
Turn off metadata service in mini commons


[MC2DP-807]: https://ctds-planx.atlassian.net/browse/MC2DP-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ