### PR TITLE
Revert BDC PreProd etlMapping changes

### DIFF
--- a/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
+++ b/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
@@ -55,8 +55,8 @@ etl:
     mappings:
       - name: internalstaging_subject
         doc_type: subject
-        root: subject
         type: aggregator
+        root: subject
         props:
           - name: submitter_id
           - name: project_id
@@ -179,9 +179,9 @@ etl:
                 src: _file_id
       - name: internalstaging_file
         doc_type: file
-        category: data_file
-        root: None
         type: collector
+        root: None
+        category: data_file
         props:
           - name: object_id
           - name: md5sum
@@ -213,9 +213,9 @@ etl:
               - name: project_id
       - name: internalstaging_index_file
         doc_type: index_file
-        category: index_file
         type: collector
         root: None
+        category: index_file
         props:
           - name: object_id
           - name: md5sum

--- a/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
+++ b/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
@@ -55,52 +55,52 @@ etl:
     mappings:
       - name: internalstaging_subject
         doc_type: subject
-        type: aggregator
         root: subject
+        type: aggregator
         props:
           - name: submitter_id
           - name: project_id
           - name: consent_codes
           - name: geographic_site
         aggregated_props:
-          - name: annotated_sex
+          - fn: set
+            name: annotated_sex
             path: demographics
             src: annotated_sex
-            fn: set
-          - name: race
+          - fn: set
+            name: race
             path: demographics
             src: race
-            fn: set
-          - name: ethnicity
+          - fn: set
+            name: ethnicity
             path: demographics
             src: ethnicity
-            fn: set
-          - name: _samples_count
+          - fn: count
+            name: _samples_count
             path: samples
-            fn: count
-          - name: _aliquots_count
+          - fn: count
+            name: _aliquots_count
             path: samples.aliquots
-            fn: count
-          - name: _read_groups_count
+          - fn: count
+            name: _read_groups_count
             path: samples.aliquots.read_groups
-            fn: count
-          - name: _submitted_unaligned_reads_files_count
+          - fn: count
+            name: _submitted_unaligned_reads_files_count
             path: samples.aliquots.read_groups.submitted_unaligned_reads_files
-            fn: count
-          - name: _submitted_aligned_reads_files_count
+          - fn: count
+            name: _submitted_aligned_reads_files_count
             path: samples.aliquots.read_groups.submitted_aligned_reads_files
-            fn: count
-          - name: _simple_germline_variations_count
+          - fn: count
+            name: _simple_germline_variations_count
             path: samples.aliquots.read_groups.simple_germline_variations
-            fn: count
-          - name: current_smoker_baseline
+          - fn: set
+            name: current_smoker_baseline
             path: exposures
             src: current_smoker_baseline
-            fn: set
-          - name: ever_smoker_baseline
+          - fn: set
+            name: ever_smoker_baseline
             path: exposures
             src: ever_smoker_baseline
-            fn: set
         parent_props:
           - path: studies[studies_submitter_id:submitter_id].projects[code]
           - path: studies[studies_submitter_id:submitter_id].projects[code].programs[programs_name:name]
@@ -168,25 +168,21 @@ etl:
           - index: file
             join_on: _subject_id
             props:
-              - name: object_id
-                src: object_id
-                fn: set
-              - name: data_format
+              - fn: set
+                name: data_format
                 src: data_format
-                fn: set
-              - name: data_type
+              - fn: set
+                name: data_type
                 src: data_type
-                fn: set
-              - name: file_count
+              - fn: count
+                name: file_count
                 src: _file_id
-                fn: count
       - name: internalstaging_file
         doc_type: file
-        type: collector
-        root: None
         category: data_file
+        root: None
+        type: collector
         props:
-          - name: project_id
           - name: object_id
           - name: md5sum
           - name: file_name
@@ -201,26 +197,26 @@ etl:
         injecting_props:
           program:
             props:
-              - name: programs_name
+              - fn: set
+                name: programs_name
                 src: name
-                fn: set
           project:
             props:
-              - name: dbgap_accession_number
+              - fn: set
+                name: dbgap_accession_number
                 src: dbgap_accession_number
-                fn: set
           subject:
             props:
-              - name: _subject_id
+              - fn: set
+                name: _subject_id
                 src: id
-                fn: set
+              - name: project_id
       - name: internalstaging_index_file
         doc_type: index_file
+        category: index_file
         type: collector
         root: None
-        category: index_file
         props:
-          - name: project_id
           - name: object_id
           - name: md5sum
           - name: file_name
@@ -235,19 +231,20 @@ etl:
         injecting_props:
           program:
             props:
-              - name: programs_name
+              - fn: set
+                name: programs_name
                 src: name
-                fn: set
           project:
             props:
-              - name: dbgap_accession_number
+              - fn: set
+                name: dbgap_accession_number
                 src: dbgap_accession_number
-                fn: set
           subject:
             props:
-              - name: _subject_id
+              - fn: set
+                name: _subject_id
                 src: id
-                fn: set
+              - name: project_id
   image:
     tube:
       tag: '2026.04'

--- a/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
+++ b/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
@@ -168,32 +168,17 @@ etl:
           - index: file
             join_on: _subject_id
             props:
-              - name: file_object_id
+              - name: object_id
                 src: object_id
                 fn: set
-              - name: file_data_format
+              - name: data_format
                 src: data_format
                 fn: set
-              - name: file_data_type
+              - name: data_type
                 src: data_type
                 fn: set
               - name: file_count
                 src: _file_id
-                fn: count
-          - index: index_file
-            join_on: _subject_id
-            props:
-              - name: index_file_object_id
-                src: object_id
-                fn: set
-              - name: index_file_data_format
-                src: data_format
-                fn: set
-              - name: index_file_data_type
-                src: data_type
-                fn: set
-              - name: index_file_count
-                src: _index_file_id
                 fn: count
       - name: internalstaging_file
         doc_type: file

--- a/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
+++ b/bdcatprod/preprod.gen3.biodatacatalyst.nhlbi.nih.gov/values/values.yaml
@@ -63,44 +63,44 @@ etl:
           - name: consent_codes
           - name: geographic_site
         aggregated_props:
-          - fn: set
-            name: annotated_sex
+          - name: annotated_sex
             path: demographics
             src: annotated_sex
-          - fn: set
-            name: race
+            fn: set
+          - name: race
             path: demographics
             src: race
-          - fn: set
-            name: ethnicity
+            fn: set
+          - name: ethnicity
             path: demographics
             src: ethnicity
-          - fn: count
-            name: _samples_count
+            fn: set
+          - name: _samples_count
             path: samples
-          - fn: count
-            name: _aliquots_count
+            fn: count
+          - name: _aliquots_count
             path: samples.aliquots
-          - fn: count
-            name: _read_groups_count
+            fn: count
+          - name: _read_groups_count
             path: samples.aliquots.read_groups
-          - fn: count
-            name: _submitted_unaligned_reads_files_count
+            fn: count
+          - name: _submitted_unaligned_reads_files_count
             path: samples.aliquots.read_groups.submitted_unaligned_reads_files
-          - fn: count
-            name: _submitted_aligned_reads_files_count
+            fn: count
+          - name: _submitted_aligned_reads_files_count
             path: samples.aliquots.read_groups.submitted_aligned_reads_files
-          - fn: count
-            name: _simple_germline_variations_count
+            fn: count
+          - name: _simple_germline_variations_count
             path: samples.aliquots.read_groups.simple_germline_variations
-          - fn: set
-            name: current_smoker_baseline
+            fn: count
+          - name: current_smoker_baseline
             path: exposures
             src: current_smoker_baseline
-          - fn: set
-            name: ever_smoker_baseline
+            fn: set
+          - name: ever_smoker_baseline
             path: exposures
             src: ever_smoker_baseline
+            fn: set
         parent_props:
           - path: studies[studies_submitter_id:submitter_id].projects[code]
           - path: studies[studies_submitter_id:submitter_id].projects[code].programs[programs_name:name]
@@ -168,15 +168,18 @@ etl:
           - index: file
             join_on: _subject_id
             props:
-              - fn: set
-                name: data_format
+              - name: object_id
+                src: object_id
+                fn: set
+              - name: data_format
                 src: data_format
-              - fn: set
-                name: data_type
+                fn: set
+              - name: data_type
                 src: data_type
-              - fn: count
-                name: file_count
+                fn: set
+              - name: file_count
                 src: _file_id
+                fn: count
       - name: internalstaging_file
         doc_type: file
         type: collector
@@ -197,19 +200,19 @@ etl:
         injecting_props:
           program:
             props:
-              - fn: set
-                name: programs_name
+              - name: programs_name
                 src: name
+                fn: set
           project:
             props:
-              - fn: set
-                name: dbgap_accession_number
+              - name: dbgap_accession_number
                 src: dbgap_accession_number
+                fn: set
           subject:
             props:
-              - fn: set
-                name: _subject_id
+              - name: _subject_id
                 src: id
+                fn: set
               - name: project_id
       - name: internalstaging_index_file
         doc_type: index_file
@@ -231,19 +234,19 @@ etl:
         injecting_props:
           program:
             props:
-              - fn: set
-                name: programs_name
+              - name: programs_name
                 src: name
+                fn: set
           project:
             props:
-              - fn: set
-                name: dbgap_accession_number
+              - name: dbgap_accession_number
                 src: dbgap_accession_number
+                fn: set
           subject:
             props:
-              - fn: set
-                name: _subject_id
+              - name: _subject_id
                 src: id
+                fn: set
               - name: project_id
   image:
     tube:


### PR DESCRIPTION
Recent updates conflict with current explorer configuration. Temporarily revert changes as we are preparing for a release. 