### PR TITLE
Change HEAL generic wkspc image to use welcome notebook (preprod)

### DIFF
--- a/healprod/preprod.healdata.org/values/values.yaml
+++ b/healprod/preprod.healdata.org/values/values.yaml
@@ -208,7 +208,7 @@ hatchery:
             "cpu-limit": "1.0",
             "memory-limit": "2Gi",
             "name": "JupyterLab with Python and R Kernels",
-            "image": "quay.io/cdis/jupyter-superslim-heal:feat_heal-superslim",
+            "image": "quay.io/repository/cdis/heal-notebooks:generic_rkernel__latest",
             "env": {
               "FRAME_ANCESTORS": "https://preprod.healdata.org"
             },


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/HP-2697

### Environments
preprod HEAL

### Description of changes
For the generic workspace image (JupyterLab with Python and R Kernels), we want it to use a welcome notebook instead of a welcome markdown. This change updates the image to use that tagged image, and adds a line to automatically launch that notebook when the image is launched.
