### PR TITLE
Set HEAL generic wkspc to use notebook welcome page

### DIFF
--- a/healprod/preprod.healdata.org/values/values.yaml
+++ b/healprod/preprod.healdata.org/values/values.yaml
@@ -214,7 +214,7 @@ hatchery:
             },
             "args": [
               "--JupyterNotebookApp.base_url=/lw-workspace/proxy/",
-              "--JupyterNotebookApp.default_url=/lab/tree/heal-welcome.md",
+              "--JupyterNotebookApp.default_url=/lab/tree/heal-welcome.ipynb",
               "--JupyterNotebookApp.password=''",
               "--JupyterNotebookApp.token=''",
               "--JupyterNotebookApp.ip='*'",


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/HP-2697

### Environments
preprod HEAL

### Description of changes
For the generic workspace image, update the launch page to be the new welcome notebook instead of the markdown file
