### PR TITLE
VPODC FF release 0.18 and cohort-middleware release 0.5.0

### DIFF
--- a/vadcprod/vpodc.data-commons.org/values/values.yaml
+++ b/vadcprod/vpodc.data-commons.org/values/values.yaml
@@ -417,7 +417,7 @@ ohdsi-webapi:
   enabled: true
   image:
     repository: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi
-    tag: VA-2025.10.24
+    tag: VA-2026.07.20
   externalSecrets:
     dbcreds: vadcprod-ohdsi-webapi-creds
 peregrine:

--- a/vadcprod/vpodc.data-commons.org/values/values.yaml
+++ b/vadcprod/vpodc.data-commons.org/values/values.yaml
@@ -151,7 +151,7 @@ frontend-framework:
   enabled: true
   image:
     repository: quay.io/cdis/vpodc-data-commons
-    tag: main
+    tag: 0.17
 global:
   pdb: true
   aws:

--- a/vadcprod/vpodc.data-commons.org/values/values.yaml
+++ b/vadcprod/vpodc.data-commons.org/values/values.yaml
@@ -40,7 +40,7 @@ cohort-middleware:
     cohortMiddlewareG3Auto: vadcprod-cohort-middleware-g3auto
   image:
     repository: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/cohort-middleware
-    tag: VA-2026.03.18
+    tag: 0.5.0
 dashboard:
   replicaCount: 4
   autoscaling:

--- a/vadcprod/vpodc.data-commons.org/values/values.yaml
+++ b/vadcprod/vpodc.data-commons.org/values/values.yaml
@@ -151,7 +151,7 @@ frontend-framework:
   enabled: true
   image:
     repository: quay.io/cdis/vpodc-data-commons
-    tag: 0.17
+    tag: 0.18
 global:
   pdb: true
   aws:

--- a/vadcprod/vpodc.data-commons.org/values/values.yaml
+++ b/vadcprod/vpodc.data-commons.org/values/values.yaml
@@ -40,7 +40,7 @@ cohort-middleware:
     cohortMiddlewareG3Auto: vadcprod-cohort-middleware-g3auto
   image:
     repository: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/cohort-middleware
-    tag: 0.5.0
+    tag: 0.5.1
 dashboard:
   replicaCount: 4
   autoscaling:


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
VPODC

### Description of changes
* (MC2DP-872): explorer add annotated somatic mutations filter by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/128
* Feat: add team-project into /sources by @m0nhawk in https://github.com/uc-cdis/cohort-middleware/pull/141
* Feat: enforce source-level access for multiple endpoints by @pieterlukasse in https://github.com/uc-cdis/cohort-middleware/pull/142
* (VPODC-448): Fix Attrition table step number is off by 1 by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/107
* Update referenceIdFieldInDataIndex in explorer.json by @smvgarcia in https://github.com/uc-cdis/vpodc-data-commons/pull/108
* Update field names for injecting_props by @smvgarcia in https://github.com/uc-cdis/vpodc-data-commons/pull/109
* Update explorer config to fix field names by @smvgarcia in https://github.com/uc-cdis/vpodc-data-commons/pull/110
* Update vpodc explorer.json by @ciresiemanym in https://github.com/uc-cdis/vpodc-data-commons/pull/111
* (VPODC-463) Migrate oncology primary fields to subrow by @george42-ctds in https://github.com/uc-cdis/vpodc-data-commons/pull/112
* (VPODC-494): consolidate config files by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/113
* chore: Sync from template repo for 2026-06-16 by @PlanXCyborg in https://github.com/uc-cdis/vpodc-data-commons/pull/114
* (VPODC-408): Adjust sources display in frontend PLP App by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/116
* (VPODC-408): plp app fix empty tooltip bug by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/117
* (VPODC-508): default NULL when empty in explorer by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/118
* Bump dompurify from 3.4.10 to 3.4.11 in the npm_and_yarn group across 1 directory by @dependabot[bot] in https://github.com/uc-cdis/vpodc-data-commons/pull/115
* cleanup code to run better locally and remove unused and redundent GWASUIApp by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/121
* fix cohort definitions in plp app by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/122
* (VPODC-419): start of bringing data dictionary app into vpodc by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/123
* VPODC-472: Add debouncing to fields that impact Attrition table in PLP App by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/125
* (VPODC-472): fix values not updating properly by @ocshawn in https://github.com/uc-cdis/vpodc-data-commons/pull/126
* fix: fix parsing of CurrentTeamProjectAccessible by @pieterlukasse in https://github.com/uc-cdis/vpodc-data-commons/pull/127