### PR TITLE
Use hash for new workspace image

### DIFF
--- a/healprod/preprod.healdata.org/values/values.yaml
+++ b/healprod/preprod.healdata.org/values/values.yaml
@@ -208,7 +208,7 @@ hatchery:
             "cpu-limit": "1.0",
             "memory-limit": "2Gi",
             "name": "JupyterLab with Python and R Kernels",
-            "image": "quay.io/cdis/heal-notebooks:generic_rkernel__3085a14fdf10fbdc56e6c0dad0a2463e54e3ed16",
+            "image": "quay.io/cdis/heal-notebooks:generic_rkernel__c63bf283668d8c027432757285a7f0324297b11b",
             "env": {
               "FRAME_ANCESTORS": "https://preprod.healdata.org"
             },


### PR DESCRIPTION
Link to Jira ticket if there is one: 

### Environments
preprod HEAL

### Description of changes

Update the container workspace image tag to use the hash of the commit to force it to update to the new workspace image