### PR TITLE
Add namespace to qag agent and mcp resources

### DIFF
--- a/gen3-ai/cluster-values/custom-objects/qag.yaml
+++ b/gen3-ai/cluster-values/custom-objects/qag.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: qag-agent-model-config
+  namespace: default
 data:
   model-config.yaml: |
     backends:
@@ -22,6 +23,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qag-agent
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -70,6 +72,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: qag-agent
+  namespace: default
 spec:
   type: NodePort
   selector:
@@ -83,6 +86,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qag-mcp
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -113,6 +117,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: qag-mcp
+  namespace: default
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Added namespace 'default' to ConfigMap, Deployments, and Services for qag-agent and qag-mcp.

Link to Jira ticket if there is one: 

### Environments
gen3ai

### Description of changes
Added namespaces to custom objects
