### PR TITLE
BDC Prod Remove banner message from gitops.json

### DIFF
--- a/bdcatprod/gen3.biodatacatalyst.nhlbi.nih.gov/values/portal/gitops.json
+++ b/bdcatprod/gen3.biodatacatalyst.nhlbi.nih.gov/values/portal/gitops.json
@@ -36,13 +36,6 @@
   },
   "components": {
     "appName": "NHLBI BioData Catalyst®",
-    "banner": [
-      {
-        "type": "info",
-        "message": "Data transfers from BDC-Gen3 to BDC-Seven Bridges may be slower than expected. Teams are actively working to improve this experience.  Check the Activity Center in BDC-Seven Bridges to track imports. If you experience issues, please report it to the BDC Help Desk: https://biodatacatalyst.nhlbi.nih.gov/help-and-support/contact-us/",
-        "resetMsgDays": 1
-      }
-    ],
     "index": {
       "introduction": {
         "heading": "",


### PR DESCRIPTION
Removed the banner message about data transfer speeds and support contact.

Link to Jira ticket if there is one: 

### Environments
BDC Staging

### Description of changes

